### PR TITLE
changing if not exists to MERGE to 100% prevent duplicates

### DIFF
--- a/dbo.assignToSeries.StoredProcedure.sql
+++ b/dbo.assignToSeries.StoredProcedure.sql
@@ -12,31 +12,13 @@ CREATE PROCEDURE [dbo].[assignToSeries]
 	@UnsubscribeToken nchar(30)
 )
 AS
-DECLARE
-	@count int
 
-	SELECT @count = 0
-	
-	SELECT @count = COUNT(*) FROM DiscipleshipSeriesUserConnection WHERE SeriesID = @SeriesID
-	AND UserID = @UserID
-IF (@count = 0)
-BEGIN
-	/* Insert user into series starting now, and last sent is 0 */
-	INSERT INTO DiscipleshipSeriesUserConnection
-	(
-		SeriesID,
-		UserID,
-		LastSection,
-		StartDate,
-		UnsubscribeToken
-	) OUTPUT Inserted.SeriesUserConnectionID
-	VALUES
-	(
-		@SeriesID,
-		@UserID,
-		0,
-		convert(date, getdate()),
-		@UnsubscribeToken
-	)
-END
+MERGE DiscipleshipSeriesUserConnection as [Target]
+USING  (select @UserID as UserId, @SeriesID as SeriesId) as [Source]
+	(UserID, SeriesID) on [Target].UserId =[Source].UserId AND [Target].SeriesID = [Source].SeriesID
+WHEN NOT MATCHED THEN
+    INSERT (SeriesID,UserID,LastSection,StartDate,UnsubscribeToken)
+	VALUES (@SeriesID,@UserID,0,convert(date, getdate()),@UnsubscribeToken);
+
+
 GO


### PR DESCRIPTION
There were intermittent reports of duplicate subscriptions getting added and under load an If Exists -> Insert can create false positives.  A MERGE statement is the foolproof way to go.  

Once this is approved I'd like for it to get deployed asap.  

 